### PR TITLE
Update sql_parse.php

### DIFF
--- a/phpBB/includes/sql_parse.php
+++ b/phpBB/includes/sql_parse.php
@@ -80,7 +80,7 @@ function remove_remarks($sql)
 	{
 		if (($i != ($linecount - 1)) || (strlen($lines[$i]) > 0))
 		{
-			if ($lines[$i][0] != "#")
+			if (!empty($lines[$i]) && $lines[$i][0] != "#")
 			{
 				$output .= $lines[$i] . "\n";
 			}


### PR DESCRIPTION
Warning: Uninitialized string offset 0 in C:\wamp\www\importal\includes\sql_parse.php on line 83

This fixes this error I was receiving while trying to restore a DB made from phpmyadmin

